### PR TITLE
Refactor/year-selector Refactor YearSelector into a common component

### DIFF
--- a/src/components/Dashboard/Selector/index.tsx
+++ b/src/components/Dashboard/Selector/index.tsx
@@ -1,5 +1,5 @@
 import { useSelection } from "../../../context/useSelection";
-import YearSelector from "../../Map/YearSelector";
+import YearSelector from "../../common/YearSelector";
 import AreaSelector from "./AreaSelector";
 
 const Selector = () => {

--- a/src/components/Dashboard/Selector/index.tsx
+++ b/src/components/Dashboard/Selector/index.tsx
@@ -1,4 +1,5 @@
 import { useSelection } from "../../../context/useSelection";
+import YearSelector from "../../Map/YearSelector";
 import AreaSelector from "./AreaSelector";
 
 const Selector = () => {
@@ -6,6 +7,9 @@ const Selector = () => {
 
   return (
     <div className="selector-wrapper">
+      <div className="selector-mode">
+        <YearSelector mode="selector" />
+      </div>
       <div className="country" onClick={clearArea}>
         全國
       </div>

--- a/src/components/Map/YearSelector/index.tsx
+++ b/src/components/Map/YearSelector/index.tsx
@@ -4,7 +4,13 @@ import { yearList } from "../../../data/list";
 import useClickOutside from "../../../hooks/useClickOutside";
 import { toggleDropdown } from "../../../utils/toggleDropdown";
 
-const YearSelector = () => {
+type Mode = "map" | "selector";
+
+interface YearSelectorProps {
+  mode: Mode;
+}
+
+const YearSelector = ({ mode }: YearSelectorProps) => {
   const { selectedYear, setSelectedYear } = useSelection();
   const [showList, setShowList] = useState(false);
   const listRef = useRef<HTMLDivElement>(null);
@@ -17,9 +23,9 @@ const YearSelector = () => {
   };
 
   return (
-    <div className="year-selector" ref={listRef}>
+    <div style={{ position: "relative" }} ref={listRef}>
       {showList && (
-        <ul>
+        <ul className={mode === "selector" ? "expand-down" : ""}>
           {yearList.map((year) => (
             <li
               key={year}

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -5,7 +5,9 @@ const Map = () => {
   return (
     <section className="map-wrapper">
       <Taiwan />
-      <YearSelector />
+      <div className="map-mode">
+        <YearSelector mode="map" />
+      </div>
     </section>
   );
 };

--- a/src/components/Map/index.tsx
+++ b/src/components/Map/index.tsx
@@ -1,5 +1,5 @@
+import YearSelector from "../common/YearSelector";
 import Taiwan from "./Taiwan";
-import YearSelector from "./YearSelector";
 
 const Map = () => {
   return (

--- a/src/components/common/YearSelector.tsx
+++ b/src/components/common/YearSelector.tsx
@@ -1,8 +1,8 @@
 import { useRef, useState } from "react";
-import { useSelection } from "../../../context/useSelection";
-import { yearList } from "../../../data/list";
-import useClickOutside from "../../../hooks/useClickOutside";
-import { toggleDropdown } from "../../../utils/toggleDropdown";
+import { useSelection } from "../../context/useSelection";
+import { yearList } from "../../data/list";
+import useClickOutside from "../../hooks/useClickOutside";
+import { toggleDropdown } from "../../utils/toggleDropdown";
 
 type Mode = "map" | "selector";
 

--- a/src/styles/App.scss
+++ b/src/styles/App.scss
@@ -8,6 +8,7 @@
 @use "../styles/components/dashboard";
 @use "../styles/components/map";
 @use "../styles/components/nav";
+@use "../styles/components/year-selector";
 
 body {
   background-image: url("/src/assets/background.svg");

--- a/src/styles/components/_map.scss
+++ b/src/styles/components/_map.scss
@@ -46,32 +46,6 @@
   }
 }
 
-.year-selector {
-  position: absolute;
-  bottom: 87px;
-  left: 0;
-  z-index: 10;
-
-  display: flex;
-  flex-direction: column;
-  row-gap: 8px;
-
-  &__item {
-    padding: 15.5px 24px;
-
-    background-color: rgba(0, 0, 0, 0.6);
-    color: white;
-
-    &:hover {
-      cursor: pointer;
-    }
-
-    &__selected {
-      @include mixins.bottom-white;
-    }
-  }
-}
-
 // map svg
 
 .selected {

--- a/src/styles/components/_year-selector.scss
+++ b/src/styles/components/_year-selector.scss
@@ -1,0 +1,43 @@
+@use "../base/variables";
+@use "../base/mixins";
+
+.year-selector {
+  display: flex;
+  flex-direction: column;
+  row-gap: 8px;
+
+  &__item {
+    padding: 15.5px 24px;
+
+    background-color: rgba(0, 0, 0, 0.6);
+    color: white;
+
+    &:hover {
+      cursor: pointer;
+    }
+
+    &__selected {
+      @include mixins.bottom-white;
+    }
+  }
+}
+
+.map-mode {
+  position: absolute;
+  bottom: 87px;
+  left: 0;
+  z-index: 10;
+}
+
+.selector-mode {
+  display: none;
+
+  @media (max-width: variables.$tablet-screen) {
+    display: block;
+  }
+}
+
+.expand-down {
+  position: absolute;
+  top: 58px;
+}

--- a/src/styles/components/dashboard/_selector.scss
+++ b/src/styles/components/dashboard/_selector.scss
@@ -21,8 +21,7 @@
   gap: 24px;
 }
 
-.city,
-.dist {
+.city {
   position: relative;
 
   img {


### PR DESCRIPTION
### refactor

- make YearSelector independent from Map
- enable YearSelector for mobile and tablet devices

### chore

- relocate YearSelector to common folder